### PR TITLE
Fix incorrect error when invalid language passed.

### DIFF
--- a/XIVAPI.js
+++ b/XIVAPI.js
@@ -28,7 +28,7 @@ See how in https://github.com/xivapi/xivapi-js/releases/tag/v0.1.3.\n\
 
 		this.endpoint = `https://${options.staging ? 'staging.' : ''}xivapi.com`
 		if(options.language && !resources.languages.includes(options.language))
-			throw Error(`Invalid language given, must be one of: ${this.resources.languages}`)
+			throw Error(`Invalid language given, must be one of: ${resources.languages}`)
 
 		this.globalParams = {}
 


### PR DESCRIPTION
`this.resources` is not defined at the time this error would be thrown, so we use `resources` which is defined.

Example code that triggers the incorrect error:

```
const XIVAPI = require(".");
const xiv = new XIVAPI({"language": "invalid"});
```

Currently, the error is:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'languages')
    at new XIVAPI (/mnt/s/dev/git/github/roncli.com/node-roncli-com/node_modules/@xivapi/js/XIVAPI.js:31:74)
```

After this change, the error becomes:

```
Uncaught Error: Invalid language given, must be one of: en,ja,de,fr,cn,kr
    at new XIVAPI (/mnt/s/dev/git/github/xivapi-js/XIVAPI.js:31:10)
```