### PR TITLE
Add support for 'columns' property when using ElasticSearch method in search()

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -28,6 +28,7 @@ module.exports = async function(input, params = {}) {
 		// ElasticSearch JSON method
 		case 'object':
 			input.indexes = makeCSV(params.indexes)
+      input.columns = makeCSV(params.columns)
 			return reqJSON(path, input)
 
 		default:

--- a/lib/search.js
+++ b/lib/search.js
@@ -28,7 +28,7 @@ module.exports = async function(input, params = {}) {
 		// ElasticSearch JSON method
 		case 'object':
 			input.indexes = makeCSV(params.indexes)
-      input.columns = makeCSV(params.columns)
+			input.columns = makeCSV(params.columns)
 			return reqJSON(path, input)
 
 		default:


### PR DESCRIPTION
I discovered this omission when trying to use the ElasticSearch method when doing `search()` operations. I've gone ahead and added logic to parse a `columns` property--similar to how `indexes` is parsed. 

I also checked to see what happens if `columns` is omitted and the query works just fine as if no columns have been requested.