### PR TITLE
added check to data.list() in case of no ids

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -20,7 +20,8 @@ class Content extends Lib {
 		if(typeof name==='undefined')
 			throw this.throwError('data.list()','a name')
 
-		params.ids = this.parent.utils.makeCSV(params.ids)
+		if(params.ids)
+			params.ids = this.parent.utils.makeCSV(params.ids)
 
 		return this.req(`/${name}`, params)
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@xivapi/js",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@root/request": "^1.7.0"


### PR DESCRIPTION
Added check for undefined `params.ids` to fix calls to data.list() not working correctly, as shown:

![image](https://user-images.githubusercontent.com/5257035/166127303-be9873a7-850b-4bdd-a53c-1a0a53f9c5aa.png)
