### PR TITLE
request library fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@root/request": "^1.7.0"
+    "@root/request": "^1.9.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@ module.exports = {
 			console.log(`Requesting ${path} with params: `, params)
 
 		return (await request({
-			uri: `${this.endpoint + path}${Object.keys(params).length > 0 ? `?${new URLSearchParams(params).toString()}` : ''}`,
+			url: `${this.endpoint + path}${Object.keys(params).length > 0 ? `?${new URLSearchParams(params).toString()}` : ''}`,
 			json: true
 		})).body
 	},
@@ -28,7 +28,7 @@ module.exports = {
 
 		return (await request({
 			method: 'POST',
-			uri: this.endpoint + path,
+			url: this.endpoint + path,
 			body: body,
 			json: true
 		})).body


### PR DESCRIPTION
Ran into an issue while updating my website for 6.4, had to update the xivapi lib and was getting this weird issue.

The port to @root/request, from what I can tell, missed a semi-important change, as it expects `url` and not `uri` to be passed. I don't know if `uri` was used in prior versions, I wasn't able to test it because it would crash due to some other issue so I figured the best thing to do would be to fix it and bump the requests library to the version that is currently working for me.