### PR TITLE
Change the type of top level search to string

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -102,7 +102,7 @@ declare module "@xivapi/js" {
      * ```
      */
     public search(
-      input: keyof typeof SearchIndexes,
+      input: string,
       params?: DataSearchParams
     ): Promise<SearchIndexResult>;
 


### PR DESCRIPTION
The doc comment specifies that the function should take in a string as the query but the type only allows for a SearchIndex string.